### PR TITLE
Fixed typo in docstring of nxt.

### DIFF
--- a/src/the/parsatron.clj
+++ b/src/the/parsatron.clj
@@ -66,7 +66,7 @@
       (p state pcok cerr peok eerr))))
 
 (defn nxt
-  "Parse q and then q, returning q's value and discarding p's"
+  "Parse p and then q, returning q's value and discarding p's"
   [p q]  
   (bind p (fn [_] q)))
 


### PR DESCRIPTION
Just replaced q with p.
