### PR TITLE
added the 'except-char' basic parser

### DIFF
--- a/docs/guide.markdown
+++ b/docs/guide.markdown
@@ -138,6 +138,21 @@ that we can use the parsatron to parse more than just strings:
     (run (any-char) [1 2 3])
     ; RuntimeException...
 
+### except-char
+
+`except-char` parses the same as `any-char` except it specifically excludes the
+items you specify. It corresponds to the `[^abc]` regex operator to parse 
+anything except the characters `a`, `b` & `c`:
+
+    (run (any-char) "cat")
+    ; \c
+
+    (run (except-char "c") "at")
+    ; \a
+
+    (run (except-char "c) "cat"))
+    ; RuntimeException
+
 ### letter and digit
 
 `letter` and `digits` create parsers that parse and return letter characters
@@ -561,3 +576,41 @@ a `>>` inside it, just bind the value to a disposable name, like `_`:
 
     (run (float) "1.0400000")
     ; 1.04
+
+### C-style escaped strings
+
+C-style strings are all characters between two `"` characters except when:
+
+- the `"` is preceded by a `\` character, it means the literal `"` and not
+termination of the string
+- various escape characters like `\t` (tab) `\r` (carriage-return) `\n` (newline)
+
+Combining `between` and `except-char` gives you the basic feature:
+
+    ; strings should be anything between two '"' characters, except if it is
+    ; preceded by a single '\' character, then it means the '"' is part of the 
+    ; string:
+    ; "qwerty" is valid
+    ; "qwe\"rty" is valid
+
+    (defparser parse-string [] 
+      (between (char \") 
+               (char \") 
+               (many (except-char "\""))))
+
+    (run parse-string "\"aoeu\"")
+    ; (\a \o \e \u)
+
+To handle escapes properly:
+
+    (defparser string-char []
+      (choice (attempt (>> (char \\) (char \\) (always \\)))
+              (attempt (>> (char \\) (char \") (always \")))
+              (attempt (>> (char \\) (char \n) (always \newline)))
+              (attempt (>> (char \\) (char \t) (always \tab)))
+              ; other cases (maybe unicode escapes...)
+              (except-char ("\""))))
+
+    (run (string-char) "qwer\ty)
+    ; [\q \w \e \r \tab \y]
+

--- a/src/the/parsatron.clj
+++ b/src/the/parsatron.clj
@@ -247,6 +247,13 @@
   []
   (token #(char? %)))
 
+(defn except-char
+  "Consume any characters except the ones provided"
+  [exclusions]
+  (token (fn [inp]
+           (and (char? inp)
+                (not (some #(= % inp) exclusions))))))
+
 (defn digit
   "Consume a digit [0-9] character"
   []


### PR DESCRIPTION
Added `except-char` that is similar to `any-char` except that it excludes specific characters. This is useful for parsing C-style escaped strings. Also some documents that illustrates this parser's use.
