### PR TITLE
since a data structure might contain nil, test for emptiness of input ex...

### DIFF
--- a/src/the/parsatron.clj
+++ b/src/the/parsatron.clj
@@ -150,10 +150,11 @@
    test returns nil or if the input is empty"
   [consume?]
   (fn [{:keys [input pos] :as state} cok cerr eok eerr]
-    (if-let [tok (first input)]
-      (if (consume? tok)
-        (cok tok (InputState. (rest input) (inc-sourcepos pos tok)))
-        (eerr (unexpect-error (str "token '" tok "'") pos)))
+    (if-not (empty? input)
+      (let [tok (first input)]
+        (if (consume? tok)
+          (cok tok (InputState. (rest input) (inc-sourcepos pos tok)))
+          (eerr (unexpect-error (str "token '" tok "'") pos))))
       (eerr (unexpect-error "end of input" pos)))))
 
 (defn many


### PR DESCRIPTION
...plicitly.

The parser combinators here can be used on more than just strings, as the readme acknowledges, but if you use it to parse clojure data structures (lists etc.), then, since they might _contain_ `nil`, `if-let [tok (first input)] ...)` will occasionally consider the input empty even when it is not.
