### PR TITLE
Bencoding now uses sorted-map

### DIFF
--- a/src/clj/parsatron/languages/bencode.clj
+++ b/src/clj/parsatron/languages/bencode.clj
@@ -34,7 +34,7 @@
                 (always [key val]))]
     (between (char \d) (char \e)
              (let->> [entries (many entry)]
-               (always (into {} entries))))))
+               (always (into (sorted-map) entries))))))
 
 (defparser ben-value []
   (choice (ben-integer)


### PR DESCRIPTION
When computing the info hash, you take compute the hash of a bencoded dictionary. To that end it makes sense to maintain sort order of bencoded dictionaries (i.e. if you wish to rencode a decoded dictionary).

I changed the bencoding language to use a `sorted-map` instead of a `hash-map` for dictionaries.
