### PR TITLE
Removing warnings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
 (defproject the/parsatron "0.0.8-SNAPSHOT"
   :description "Clojure parser combinators"
 
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/clojurescript "0.0-2227"]]
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [org.clojure/clojurescript "1.10.339"]]
 
-  :plugins [[lein-cljsbuild "1.0.3"]]
+  :plugins [[lein-cljsbuild "1.1.7"]]
 
   :source-paths ["src/clj" "src/cljs"]
   :test-paths ["test/clj"]
@@ -12,4 +12,7 @@
   :global-vars {*warn-on-reflection* false}
 
   :cljsbuild {:builds [{:source-paths ["src/cljs" "test/cljs"]
-                        :compiler {:output-to "test/resources/parsatron_test.js"}}]})
+                        :compiler {:optimizations :simple
+                                   :target :nodejs
+                                   :output-to "test/resources/parsatron_test.js"}}]
+              :test-commands { "unit" ["node" "test/resources/parsatron_test.js"]}})

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
 (defproject the/parsatron "0.0.8-SNAPSHOT"
   :description "Clojure parser combinators"
 
-  :dependencies [[org.clojure/clojure "1.9.0"]
-                 [org.clojure/clojurescript "1.10.339"]]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [org.clojure/clojurescript "1.10.520"]]
 
   :plugins [[lein-cljsbuild "1.1.7"]]
 

--- a/src/clj/parsatron/languages/bencode.clj
+++ b/src/clj/parsatron/languages/bencode.clj
@@ -28,13 +28,20 @@
   (between (char \l) (char \e)
            (many (ben-value))))
 
+(defn comparer [a b]
+  (if (= (type a) (type b))
+    (compare a b)
+    (cond (string? a) -1
+          (string? b) 1
+          :default (compare a b))))
+
 (defparser ben-dictionary []
   (let [entry (let->> [key (ben-value)
                        val (ben-value)]
                 (always [key val]))]
     (between (char \d) (char \e)
              (let->> [entries (many entry)]
-               (always (into (sorted-map) entries))))))
+               (always (into (sorted-map-by comparer) entries))))))
 
 (defparser ben-value []
   (choice (ben-integer)

--- a/src/clj/parsatron/languages/bencode.clj
+++ b/src/clj/parsatron/languages/bencode.clj
@@ -28,20 +28,13 @@
   (between (char \l) (char \e)
            (many (ben-value))))
 
-(defn comparer [a b]
-  (if (and (string? a) (string? b))
-    (compare a b)
-    (throw (ex-info "Dictionary keys must be strings"
-                    (let [faulty-key (if (string? a) b a)]
-                      {:key faulty-key :type (type faulty-key)})))))
-
 (defparser ben-dictionary []
-  (let [entry (let->> [key (ben-value)
+  (let [entry (let->> [key (ben-bytestring)
                        val (ben-value)]
                 (always [key val]))]
     (between (char \d) (char \e)
              (let->> [entries (many entry)]
-               (always (into (sorted-map-by comparer) entries))))))
+               (always (into (sorted-map) entries))))))
 
 (defparser ben-value []
   (choice (ben-integer)

--- a/src/clj/parsatron/languages/bencode.clj
+++ b/src/clj/parsatron/languages/bencode.clj
@@ -29,11 +29,11 @@
            (many (ben-value))))
 
 (defn comparer [a b]
-  (if (= (type a) (type b))
+  (if (and (string? a) (string? b))
     (compare a b)
-    (cond (string? a) -1
-          (string? b) 1
-          :default (compare a b))))
+    (throw (ex-info "Dictionary keys must be strings"
+                    (let [faulty-key (if (string? a) b a)]
+                      {:key faulty-key :type (type faulty-key)})))))
 
 (defparser ben-dictionary []
   (let [entry (let->> [key (ben-value)

--- a/src/cljs/the/parsatron.cljs
+++ b/src/cljs/the/parsatron.cljs
@@ -1,5 +1,5 @@
 (ns the.parsatron
-  (:refer-clojure :exclude [char])
+  (:refer-clojure :exclude [char char?])
   (:require [clojure.string :as str])
   (:require-macros [the.parsatron :refer [defparser >> let->>]]))
 

--- a/test/clj/parsatron/languages/test_bencode.clj
+++ b/test/clj/parsatron/languages/test_bencode.clj
@@ -18,4 +18,16 @@
 
 (deftest test-ben-dictionary
   (are [expected input] (= expected (run (ben-dictionary) input))
-       {42 "spam", "spam" 42} "di42e4:spam4:spami42ee"))
+       {"42" "spam", "spam" 42} "d2:424:spam4:spami42ee"
+       {"spam" ["a" "b"]} "d4:spaml1:a1:bee"
+       {"name" "Mary"
+        "age" 33
+        "children" ["Betty", "Sam"]
+        "address" {"street" "1 Home St"
+                   "city" "Anywhere"}}
+        "d4:name4:Mary3:agei33e8:childrenl5:Betty3:Same7:addressd6:street9:1 Home St4:city8:Anywhereee")
+  (let [ex (is (thrown-with-msg?
+                 clojure.lang.ExceptionInfo #"Dictionary keys must be strings"
+                 (run (ben-dictionary) "di42e4:spam4:spami42ee")))]
+    (is (= {:key 42, :type java.lang.Long} (ex-data ex)))))
+

--- a/test/clj/parsatron/languages/test_bencode.clj
+++ b/test/clj/parsatron/languages/test_bencode.clj
@@ -26,8 +26,5 @@
         "address" {"street" "1 Home St"
                    "city" "Anywhere"}}
         "d4:name4:Mary3:agei33e8:childrenl5:Betty3:Same7:addressd6:street9:1 Home St4:city8:Anywhereee")
-  (let [ex (is (thrown-with-msg?
-                 clojure.lang.ExceptionInfo #"Dictionary keys must be strings"
-                 (run (ben-dictionary) "di42e4:spam4:spami42ee")))]
-    (is (= {:key 42, :type java.lang.Long} (ex-data ex)))))
+  (is (thrown?  RuntimeException (run (ben-dictionary) "di42e4:spam4:spami42ee"))))
 


### PR DESCRIPTION
This addresses warnings that occurred with ClojureScript. Also, fixed the bencode tests that failed. Updated Clojure, ClojureScript and lein-cljsbuild as the older versions led to warnings.